### PR TITLE
Mediator refactor

### DIFF
--- a/src/Nox.Solution/Enums/MessagingServerProvider.cs
+++ b/src/Nox.Solution/Enums/MessagingServerProvider.cs
@@ -5,10 +5,10 @@ namespace Nox
 {
     public enum MessagingServerProvider
     {
-        MediatR,
         RabbitMq,
         AzureServiceBus,
         AmazonSqs,
+        InMemory
     }
     
     public static class MessagingServerProviderHelpers

--- a/src/Nox.Solution/Models/Infrastructure/Messaging/Messaging.cs
+++ b/src/Nox.Solution/Models/Infrastructure/Messaging/Messaging.cs
@@ -6,9 +6,10 @@ namespace Nox
     [AdditionalProperties(false)]
     public class Messaging
     {
-        [Required]
-        [AdditionalProperties(false)]
-        public  MessagingServer? DomainEventServer { get; internal set; }
+        //removed this as we will always create a domain event server internally using MassTransit Mediator
+        // [Required]
+        // [AdditionalProperties(false)]
+        // public  MessagingServer? DomainEventServer { get; internal set; }
 
         [Required]
         [AdditionalProperties(false)]

--- a/src/Nox.Solution/Validation/Infrastructure/InfrastructureValidator.cs
+++ b/src/Nox.Solution/Validation/Infrastructure/InfrastructureValidator.cs
@@ -51,7 +51,6 @@ namespace Nox.Validation.Infrastructure
 
                 if (infra.Messaging != null)
                 {
-                    if (infra.Messaging.DomainEventServer != null) servers.Add(infra.Messaging.DomainEventServer);
                     if (infra.Messaging.IntegrationEventServer != null) servers.Add(infra.Messaging.IntegrationEventServer);
                 }
 

--- a/src/Nox.Solution/Validation/Infrastructure/Messaging/MessagingValidator.cs
+++ b/src/Nox.Solution/Validation/Infrastructure/Messaging/MessagingValidator.cs
@@ -8,9 +8,6 @@ namespace Nox.Validation.Infrastructure.Messaging
     {
         public MessagingValidator(IEnumerable<ServerBase>? servers)
         {
-            RuleFor(p => p.DomainEventServer!)
-                .SetValidator(v => new ServerBaseValidator("the infrastructure, messaging, domain event server", servers));
-            
             RuleFor(p => p.IntegrationEventServer!)
                 .SetValidator(v => new ServerBaseValidator("the infrastructure, messaging, integration event server", servers));
         }

--- a/tests/Nox.Solution.Tests/SolutionDeserializationTests.cs
+++ b/tests/Nox.Solution.Tests/SolutionDeserializationTests.cs
@@ -280,9 +280,6 @@ public class SolutionDeserializationTests
         Assert.Equal("EvtPassword", noxConfig!.Infrastructure.Persistence.EventSourceServer.Password);
         
         Assert.NotNull(noxConfig!.Infrastructure.Messaging);
-        Assert.NotNull(noxConfig!.Infrastructure.Messaging.DomainEventServer);
-        Assert.Equal("MediatR", noxConfig!.Infrastructure.Messaging.DomainEventServer.Name);
-        Assert.Equal(MessagingServerProvider.MediatR, noxConfig!.Infrastructure.Messaging.DomainEventServer.Provider);
         
         Assert.NotNull(noxConfig!.Infrastructure.Messaging.IntegrationEventServer);
         Assert.Equal("IntegrationBus", noxConfig!.Infrastructure.Messaging.IntegrationEventServer.Name);


### PR DESCRIPTION
- Removed Infrastructure.DomainEventServer from yaml definition. We will always use the Mediator for inprocess messaging, and it will be added by Nox.Lib automagically

- Removed Mediator from MessagingServerProvider.cs