### PR TITLE
test yaml solution files

### DIFF
--- a/src/Nox.Solution/Models/VersionControl/VersionControl.cs
+++ b/src/Nox.Solution/Models/VersionControl/VersionControl.cs
@@ -6,7 +6,7 @@ namespace Nox.Solution
     [AdditionalProperties(false)]
     public enum VersionControlProvider
     {
-        AzureDevops
+        AzureDevops = 1
     }
 
     [Title("Source code repository and related info for the solution.")]
@@ -18,7 +18,7 @@ namespace Nox.Solution
         [Title("The source code and repository provider or service.")]
         [Description("The name of the provider or service for source code and version control")]
         [Pattern(@"^[^\s]*$")]
-        public VersionControlProvider Provider { get; internal set; } = VersionControlProvider.AzureDevops;
+        public VersionControlProvider? Provider { get; internal set; }
 
         [Required]
         [Title("The URI for the host of the version control service.")]

--- a/src/Nox.Solution/Validation/VersionControl/VersionControlValidator.cs
+++ b/src/Nox.Solution/Validation/VersionControl/VersionControlValidator.cs
@@ -10,6 +10,7 @@ namespace Nox.Solution.Validation
                 .NotNull()
                 .WithMessage(vc => string.Format(ValidationResources.VersionControlProviderEmpty));
 
+
             RuleFor(vc => vc.Host)
                 .NotEmpty()
                 .WithMessage(vc => string.Format(ValidationResources.VersionControlHostEmpty));

--- a/tests/Nox.Solution.Tests/Nox.Solution.Tests.csproj
+++ b/tests/Nox.Solution.Tests/Nox.Solution.Tests.csproj
@@ -22,6 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -60,6 +61,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="files\invalid-version-control.solution.nox.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="files\invalid-version-control.solution %28copy%29.nox.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/tests/Nox.Solution.Tests/ValidationTests.cs
+++ b/tests/Nox.Solution.Tests/ValidationTests.cs
@@ -1,16 +1,58 @@
+
+using FluentAssertions;
+using FluentValidation;
+using Nox.Solution.Exceptions;
+
+
 namespace Nox.Solution.Tests;
 
 public class ValidationTests
 {
-    [Fact]
-    public void Environment_names_are_unique()
+    [Theory]
+    [InlineData("unsupported-version-control.solution.nox")]
+    [InlineData("not-found.yaml")]
+    public void WhenInvalidYamlNotShouldThrowException(string filrName)
     {
-        var ex = Assert.Throws<FluentValidation.ValidationException>(() =>
-            _ = new NoxSolutionBuilder()
-                .UseYamlFile("./files/duplicate-environment-name.solution.nox.yaml")
-                .Build()
-        );
+        var solutionBuilder = new NoxSolutionBuilder().UseYamlFile($"./files/{filrName}");
 
-        Assert.Equal("The environment name 'test' is duplicated. Environment names must be unique in a solution.", ex.Errors.First().ErrorMessage);
+        solutionBuilder
+            .Invoking(solution => solution.Build())
+            .Should().Throw<NoxSolutionConfigurationException>();            
+    }
+    
+    [Theory]
+    [InlineData("duplicate-environment-name.solution.nox.yaml", "The environment name 'test' is duplicated. Environment names must be unique in a solution.")]
+    [InlineData("invalid-version-control.solution.nox.yaml", "Version Control provider missing. a Version Control Provider must be specified in a solution.")]
+    public void WhenInvalidConfigurationShouldThrowValidationException(string ymlFileName, string expectedErrorMessage)
+    {              
+       Action act = () => new NoxSolutionBuilder()
+                .UseYamlFile($"./files/{ymlFileName}")
+                .Build()
+                .Validate();
+       
+        act.Should()
+            .Throw<ValidationException>()
+            .Where(exception => exception.Errors.First().ErrorMessage.Contains(expectedErrorMessage));       
+    }
+
+    [Theory]
+    [InlineData("application.solution.nox.yaml")]
+    [InlineData("domain.solution.nox.yaml")]    
+    [InlineData("environments.solution.nox.yaml")]    
+    [InlineData("infrastructure.solution.nox.yaml")]        
+    [InlineData("minimal.solution.nox.yaml")]
+    [InlineData("sample.solution.nox.yaml")]
+    [InlineData("team.solution.nox.yaml")]
+    [InlineData("variables.solution.nox.yaml")]
+    [InlineData("version-control.solution.nox.yaml")]    
+    public void WhenValidConfigurationShouldValidate(string ymlFileName)
+    {
+        var noxSolution = new NoxSolutionBuilder()
+                .UseYamlFile($"./files/{ymlFileName}")
+                .Build();
+
+        noxSolution
+            .Invoking(solution => solution.Validate())
+            .Should().NotThrow();
     }
 }

--- a/tests/Nox.Solution.Tests/files/unsupported-version-control.solution.nox.yaml
+++ b/tests/Nox.Solution.Tests/files/unsupported-version-control.solution.nox.yaml
@@ -1,0 +1,10 @@
+name: TestService
+
+description: Yaml file for testing version control
+
+versionControl:
+  provider: github
+  host: https://dev.azure.com/iwgplc
+  folders:
+    sourceCode: /src
+    containers: /docker


### PR DESCRIPTION
Test for invalid, invalid configuration and valid yaml files 
add FluentAssertions package for making assertion easier and more readable
create a test for valid yaml files
update invalid test case to accept inline data instead of a test for each file Add FluentAssertions dependency
Set VersionControlProvider.AzureDevops to 1 explicitly and made it nullable, so the user needs to define it explicitly