### PR TITLE
replace passwords, secrets, other in yaml by environment variables

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,17 @@
+## Environment Variables for Sensitive Data
+
+Do not commit or keep sensitive data on your yaml solution files.
+
+The current way to this is by using Environment Variables.
+
+### Example
+Nox will expand any text with the following convention  ``${{ env.VAR_NAME }}`` to the value of **VAR_NAME** Environment Variable if found.
+Sample Yaml:
+
+    databaseServer:
+        name: SampleCurrencyDb
+        serverUri: ${{ env.DB_SERVER }}
+        provider: sqlServer
+        port: 1433
+        user: ${{ env.DB_USER }}
+        password: ${{ env.DB_PASSWORD }}

--- a/src/Nox.Solution.sln
+++ b/src/Nox.Solution.sln
@@ -7,6 +7,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nox.Solution", "Nox.Solutio
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nox.Solution.Tests", "..\tests\Nox.Solution.Tests\Nox.Solution.Tests.csproj", "{287B16A3-7567-4B85-B4BE-C810CBBB00DC}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{C887482C-39E9-4988-8D18-E5D4683E8DBA}"
+	ProjectSection(SolutionItems) = preProject
+		..\readme.md = ..\readme.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Nox.Solution/Macros/EnvironmentVariableMacroParser.cs
+++ b/src/Nox.Solution/Macros/EnvironmentVariableMacroParser.cs
@@ -21,6 +21,7 @@ public class EnvironmentVariableMacroParser: IMacroParser
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .Build();
     }
+
     public string Parse(string text)
     {
         var parsed = text;

--- a/src/Nox.Solution/Macros/EnvironmentVariableMacroParser.cs
+++ b/src/Nox.Solution/Macros/EnvironmentVariableMacroParser.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Nox.Solution.Utils;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Nox.Solution.Macros;
+
+public class EnvironmentVariableMacroParser: IMacroParser
+{
+    private readonly IEnvironmentProvider _environmentProvider;
+    private readonly Regex _regex = new Regex(@"\$\{{\s*env.\S+\s*\}}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(10000));
+    private readonly ISerializer _serializer;
+
+    public EnvironmentVariableMacroParser(IEnvironmentProvider environmentProvider)
+    {
+        _environmentProvider = environmentProvider;
+
+        _serializer = new SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build();
+    }
+    public string Parse(string text)
+    {
+        var parsed = text;
+        MatchCollection? matched = default;
+        try
+        {
+            matched = _regex.Matches(text);
+        }
+        catch (RegexMatchTimeoutException e)
+        {
+            Debug.WriteLine(e);
+            Console.WriteLine(e);
+            return text;
+        }
+
+        for (int count = 0; count < matched.Count; count++)
+        {
+            var match = matched[count];
+            //Example: "${{ env.SECRETS_PASSWORD   }}"
+            //Remove Start "${{", Remove End "}}"
+            var variableName = match.Value.Substring(3, match.Value.Length - 3 - 2).Trim();
+            //var variableName = match.Value[3..^2].Trim(); (in .Net Standard 2.1 we can use Range)
+            //Remove "env."
+            variableName = variableName.Substring(4);
+
+            var environmentValue = _environmentProvider.GetEnvironmentVariable(variableName);
+
+            if (environmentValue != null)
+            {
+                //Ensure special characters in password, for example @"#{}$%@'\\", are yaml valid values
+                environmentValue = _serializer.Serialize(environmentValue);
+                parsed = parsed.Replace(match.Value, environmentValue);
+            }
+        }
+
+        return parsed;
+    }
+}

--- a/src/Nox.Solution/Macros/IMacroParser.cs
+++ b/src/Nox.Solution/Macros/IMacroParser.cs
@@ -1,0 +1,9 @@
+namespace Nox.Solution.Macros;
+
+public interface IMacroParser
+{
+    /// <summary>
+    /// Looks and Expands Macros found in the Text
+    /// </summary>
+    string Parse(string text);
+}

--- a/src/Nox.Solution/Macros/MacroParser.cs
+++ b/src/Nox.Solution/Macros/MacroParser.cs
@@ -1,0 +1,8 @@
+using Nox.Solution.Utils;
+
+namespace Nox.Solution.Macros;
+
+public static class MacroParser
+{
+    public static readonly IMacroParser[] Defaults = new IMacroParser[]{new EnvironmentVariableMacroParser(new EnvironmentProvider())};
+}

--- a/src/Nox.Solution/NoxSolutionBuilder.cs
+++ b/src/Nox.Solution/NoxSolutionBuilder.cs
@@ -4,6 +4,7 @@ using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using Nox.Solution.Exceptions;
 using Nox.Solution.Macros;
+using Nox.Solution.Utils;
 
 namespace Nox.Solution
 {
@@ -12,7 +13,8 @@ namespace Nox.Solution
         private const string DesignFolderBestPractice = "Best practice is to create a '.nox' folder in your solution folder and in there a 'design' folder which contains your <solution-name>.solution.nox.yaml";
 
         private string _yamlFilePath = string.Empty;
-        private IMacroParser[]? _macroParsers;
+
+        private IMacroParser _environmentVariableParser = new EnvironmentVariableMacroParser(new EnvironmentProvider());
 
         public NoxSolutionBuilder UseYamlFile(string yamlFilePath)
         {
@@ -20,9 +22,9 @@ namespace Nox.Solution
             return this;
         }
 
-        public NoxSolutionBuilder UseMacros(IMacroParser[] macroParsers)
+        public NoxSolutionBuilder UseEnvironmentMacroParser(EnvironmentVariableMacroParser parser)
         {
-            _macroParsers = macroParsers;
+            _environmentVariableParser = parser;
             return this;
         }
 
@@ -140,13 +142,7 @@ namespace Nox.Solution
 
         private string ExpandMacros(string yaml)
         {
-            if (_macroParsers != null)
-            {
-                for (var i = 0; i < _macroParsers.Length; i++)
-                {
-                    yaml = _macroParsers[i].Parse(yaml);
-                }
-            }
+            yaml = _environmentVariableParser.Parse(yaml);
 
             return yaml;
         }

--- a/src/Nox.Solution/Utils/EnvironmentProvider.cs
+++ b/src/Nox.Solution/Utils/EnvironmentProvider.cs
@@ -1,0 +1,9 @@
+namespace Nox.Solution.Utils;
+
+internal sealed class EnvironmentProvider : IEnvironmentProvider
+{
+    public string? GetEnvironmentVariable(string variable)
+    {
+        return System.Environment.GetEnvironmentVariable(variable);
+    }
+}

--- a/src/Nox.Solution/Utils/IEnvironmentProvider.cs
+++ b/src/Nox.Solution/Utils/IEnvironmentProvider.cs
@@ -1,0 +1,10 @@
+namespace Nox.Solution.Utils;
+
+/// <summary>
+/// Create an indirection to access Environment Variables
+/// Do not depend on static instances
+/// </summary>
+public interface IEnvironmentProvider
+{
+    string? GetEnvironmentVariable(string variable);
+}

--- a/tests/Nox.Solution.Tests/Macros/EnvironmentVariableMacroParserTest.cs
+++ b/tests/Nox.Solution.Tests/Macros/EnvironmentVariableMacroParserTest.cs
@@ -6,6 +6,7 @@ namespace Nox.Solution.Tests.Macros;
 
 public class EnvironmentVariableMacroParserTest
 {
+
     [Fact]
     public void When_Parsing_Macros_Should_Replace_EnvironmentVariables()
     {
@@ -20,7 +21,7 @@ public class EnvironmentVariableMacroParserTest
 
         var noxConfig = new NoxSolutionBuilder()
             .UseYamlFile("./files/macros/sample.solution.nox.yaml")
-            .UseMacros(new IMacroParser[]{new EnvironmentVariableMacroParser(environmentProvider.Object)})
+            .UseEnvironmentMacroParser(new EnvironmentVariableMacroParser(environmentProvider.Object))
             .Build();
 
         Assert.NotNull(noxConfig);
@@ -33,4 +34,19 @@ public class EnvironmentVariableMacroParserTest
         Assert.Equal("secretpwd1",noxConfig.Infrastructure?.Security?.Secrets?.SecretsServer?.Password);
 
     }
+
+    [Fact]
+    public void When_Creating_NoxSolution_Uses_System_Environment_By_Default()
+    {
+        var noxConfig = new NoxSolutionBuilder()
+            .UseYamlFile("./files/macros/envvar.solution.nox.yaml")
+            .Build();
+
+        Assert.NotNull(noxConfig);
+
+        Assert.Equal("EnvTestService", noxConfig.Name);
+        Assert.NotEqual("${{ env.TEMP }} ${{ env.TMPDIR }}", noxConfig.Description);
+
+    }
+
 }

--- a/tests/Nox.Solution.Tests/Macros/EnvironmentVariableMacroParserTest.cs
+++ b/tests/Nox.Solution.Tests/Macros/EnvironmentVariableMacroParserTest.cs
@@ -38,14 +38,26 @@ public class EnvironmentVariableMacroParserTest
     [Fact]
     public void When_Creating_NoxSolution_Uses_System_Environment_By_Default()
     {
-        var noxConfig = new NoxSolutionBuilder()
-            .UseYamlFile("./files/macros/envvar.solution.nox.yaml")
-            .Build();
+        try
+        {
+            System.Environment.SetEnvironmentVariable("MyTemp","MyTemp");
+            System.Environment.SetEnvironmentVariable("MyTempDir","MyTempDir");
 
-        Assert.NotNull(noxConfig);
+            var noxConfig = new NoxSolutionBuilder()
+                .UseYamlFile("./files/macros/envvar.solution.nox.yaml")
+                .Build();
 
-        Assert.Equal("EnvTestService", noxConfig.Name);
-        Assert.NotEqual("${{ env.TEMP }} ${{ env.TMPDIR }}", noxConfig.Description);
+            Assert.NotNull(noxConfig);
+
+            Assert.Equal("EnvTestService", noxConfig.Name);
+            Assert.NotEqual("${{ env.MyTemp }} ${{ env.MyTempDir }}", noxConfig.Description);
+        }
+        finally
+        {
+            System.Environment.SetEnvironmentVariable("MyTemp",null);
+            System.Environment.SetEnvironmentVariable("MyTempDir",null);
+        }
+
 
     }
 

--- a/tests/Nox.Solution.Tests/Macros/EnvironmentVariableMacroParserTest.cs
+++ b/tests/Nox.Solution.Tests/Macros/EnvironmentVariableMacroParserTest.cs
@@ -1,0 +1,36 @@
+using Moq;
+using Nox.Solution.Macros;
+using Nox.Solution.Utils;
+
+namespace Nox.Solution.Tests.Macros;
+
+public class EnvironmentVariableMacroParserTest
+{
+    [Fact]
+    public void When_Parsing_Macros_Should_Replace_EnvironmentVariables()
+    {
+        var environmentProvider = new Mock<IEnvironmentProvider>();
+        environmentProvider.Setup(service => service.GetEnvironmentVariable("CACHE_USER")).Returns("cacheuser1");
+        environmentProvider.Setup(service => service.GetEnvironmentVariable("CACHE_PASSWORD")).Returns("cachepwd1");
+        environmentProvider.Setup(service => service.GetEnvironmentVariable("DB_PASSWORD")).Returns(@"#{}$%@'\\");
+        environmentProvider.Setup(service => service.GetEnvironmentVariable("DB_USER")).Returns("dbuser1");
+        environmentProvider.Setup(service => service.GetEnvironmentVariable("SECRETS_USER")).Returns("secretuser1");
+        environmentProvider.Setup(service => service.GetEnvironmentVariable("SECRETS_PASSWORD")).Returns("secretpwd1");
+
+
+        var noxConfig = new NoxSolutionBuilder()
+            .UseYamlFile("./files/macros/sample.solution.nox.yaml")
+            .UseMacros(new IMacroParser[]{new EnvironmentVariableMacroParser(environmentProvider.Object)})
+            .Build();
+
+        Assert.NotNull(noxConfig);
+
+        Assert.Equal("cacheuser1",noxConfig.Infrastructure?.Persistence.CacheServer?.User);
+        Assert.Equal("cachepwd1",noxConfig.Infrastructure?.Persistence.CacheServer?.Password);
+        Assert.Equal("dbuser1",noxConfig.Infrastructure?.Persistence.DatabaseServer?.User);
+        Assert.Equal(@"#{}$%@'\\",noxConfig.Infrastructure?.Persistence.DatabaseServer?.Password);
+        Assert.Equal("secretuser1",noxConfig.Infrastructure?.Security?.Secrets?.SecretsServer?.User);
+        Assert.Equal("secretpwd1",noxConfig.Infrastructure?.Security?.Secrets?.SecretsServer?.Password);
+
+    }
+}

--- a/tests/Nox.Solution.Tests/Nox.Solution.Tests.csproj
+++ b/tests/Nox.Solution.Tests/Nox.Solution.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="JsonSchema.Net.Generation" Version="3.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -61,6 +62,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="files\invalid-version-control.solution.nox.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+	<None Update="files\macros\sample.solution.nox.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="files\duplicate-domain-event.solution.nox.yaml">

--- a/tests/Nox.Solution.Tests/Nox.Solution.Tests.csproj
+++ b/tests/Nox.Solution.Tests/Nox.Solution.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -31,6 +31,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="files\macros\envvar.solution.nox.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="files\minimal.solution.nox.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/tests/Nox.Solution.Tests/files/macros/envvar.solution.nox.yaml
+++ b/tests/Nox.Solution.Tests/files/macros/envvar.solution.nox.yaml
@@ -1,0 +1,14 @@
+﻿#
+# minimal.solution.nox.yaml
+#
+# yaml-language-server: $schema=../../../../schemas/solution.json
+#
+
+name: EnvTestService
+
+# one of these should be replaced on Windows/Linux
+
+description: ${{ env.TEMP }} ${{ env.TMPDIR }}
+
+
+

--- a/tests/Nox.Solution.Tests/files/macros/sample.solution.nox.yaml
+++ b/tests/Nox.Solution.Tests/files/macros/sample.solution.nox.yaml
@@ -1,0 +1,105 @@
+#
+# workplace.solution.nox.yaml
+#
+# yaml-language-server: $schema=../../../schemas/solution.json
+#
+
+
+name: SampleServiceWithMacros
+
+description: Sample Nox solution yaml configuration
+
+variables:
+  DATABASE_PROVIDER: slqServer
+  DATABASE_SERVER: localhost
+  DATABASE_PORT: "5432"
+
+environments:
+
+  - name: dev
+    description: Used for development and testing
+
+  - name: test
+    description: Test environment
+
+  - name: uat
+    description: For them end users to check it works
+
+  - name: prod
+    description: Production environment used for, well - the real thing!
+    isProduction: true
+
+versionControl:
+  provider: azureDevops
+  host: https://dev.azure.com/iwgplc
+  folders:
+    sourceCode: /src
+    containers: /docker
+
+team:
+
+  - name: Andre Sharpe
+    userName: andre.sharpe@iwgplc.com
+    roles: [architect, owner, administrator, developer, manager]
+
+  - name: Jan Schutte
+    userName: jan.schutte@iwgplc.com
+    roles: [architect, administrator, developer, devOpsEngineer]
+
+  - name: Anton Du Plessis
+    userName: anton.duplessis@iwgplc.com
+    roles: [projectManager]
+
+  - name: Morne Van Zyl
+    userName: morne.vanzyl@iwgplc.com
+    roles: [technicalWriter]
+
+  - name: Dmytro Dorodnykh
+    userName: dmytro.dorodnykh@iwgplc.com
+    roles: [developer]
+
+  - name: Oleksandr Vlasenko
+    userName: oleksandr.vlasenko@regus.com
+    roles: [architect, developer]
+
+infrastructure:
+  
+  persistence:
+
+    databaseServer:
+      name: SampleCurrencyDb
+      serverUri: sqlserver.iwgplc.com
+      provider: sqlServer
+      port: 1433
+      user: ${{ env.DB_USER }}
+      password: ${{env.DB_PASSWORD }}
+
+    cacheServer:
+      name: SampleCache
+      provider: azureRedis
+      serverUri: redis.iwgplc.com
+      user: ${{      env.CACHE_USER         }}
+      password: ${{ env.CACHE_PASSWORD}}
+
+  messaging:
+
+    integrationEventServer:
+      name: IntegrationBus
+      provider: rabbitMq
+      serverUri: rabbitmq://localhost
+      port: 5672
+      user: guest
+      password: guest
+
+  security:
+    secrets:
+      secretsServer:
+        name: SampleSecretServer
+        provider: azureKeyVault
+        serverUri: kv.iwgplc.com
+        user: ${{   env.SECRETS_USER }}
+        password: ${{ env.SECRETS_PASSWORD   }}
+      validFor:
+        minutes: 10
+
+

--- a/tests/Nox.Solution.Tests/files/macros/sample.solution.nox.yaml
+++ b/tests/Nox.Solution.Tests/files/macros/sample.solution.nox.yaml
@@ -1,7 +1,7 @@
 #
 # workplace.solution.nox.yaml
 #
-# yaml-language-server: $schema=../../../schemas/solution.json
+# yaml-language-server: $schema=../../../../schemas/solution.json
 #
 
 


### PR DESCRIPTION
issue #7
yaml will be parsed and Macros will be replaced by environment variables if found 
This will happen before deserialization
Macro example ${{ env.RABBITMQ_SERVER }}, following GitHub  notation for environment variables